### PR TITLE
Fix prepared query in preparation

### DIFF
--- a/sources/lib/PreparedQuery/PreparationEnum.php
+++ b/sources/lib/PreparedQuery/PreparationEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PommProject\Foundation\PreparedQuery;
+
+enum PreparationEnum: string{
+    case NOT_PREPARED = 'not prepared';
+    case IN_PREPARATION = 'in preparation';
+    case PREPARED = 'prepared';
+}


### PR DESCRIPTION
Two similar requests executed simultaneously cause a 42P05 error because the second launches the preparation while the first has not yet finished the preparation.