### PR TITLE
Add enum support to PgString, PgInteger and PgFloat converters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 == VERSION 4.0.3
 
- * Accept PHP enums in PgString, PgInteger and PgFloat converters (BackedEnum unwrapped to value with backing-type check, UnitEnum converted via name for PgString)
+ * Accept PHP enums in PgString, PgInteger and PgFloat converters (scalar unwrapping with per-converter compatibility check; PgString also handles pure UnitEnum via ->name)
+ * Fix PgInteger serializing negative numbers as unsigned overflow (use %d instead of %u)
+ * Harden PgBackedEnum::toPg with an explicit instance check and string cast on the backing value
 
 == VERSION 4.0.2
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== VERSION 4.0.3
+
+ * Accept PHP enums in PgString, PgInteger and PgFloat converters (BackedEnum unwrapped to value with backing-type check, UnitEnum converted via name for PgString)
+
 == VERSION 4.0.2
 
  * Fix DSN parsing for encoded urls

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.2",
+    "version": "4.0.3",
     "name": "conserto/pomm-foundation",
     "type": "library",
     "description":  "Pomm connection manager for Postgresql",

--- a/sources/lib/Converter/PgBackedEnum.php
+++ b/sources/lib/Converter/PgBackedEnum.php
@@ -23,7 +23,7 @@ class PgBackedEnum implements ConverterInterface
     public function __construct(private readonly string $enumFqcn)
     {
         if (!enum_exists($this->enumFqcn) || !is_a($this->enumFqcn, \BackedEnum::class, true)) {
-            throw new ConverterException(sprintf('BackedEnum "%s" does not exists', $this->enumFqcn));
+            throw new ConverterException(sprintf('BackedEnum "%s" does not exist', $this->enumFqcn));
         }
     }
 
@@ -42,15 +42,25 @@ class PgBackedEnum implements ConverterInterface
         return $enum;
     }
 
+    /** @throws ConverterException */
     public function toPg(mixed $data, string $type, Session $session): string
     {
         if ($data === null) {
             return sprintf("NULL::%s", $type);
         }
 
-        return $data->value;
+        if (!$data instanceof $this->enumFqcn) {
+            throw new ConverterException(sprintf(
+                'Expected instance of "%s", got "%s".',
+                $this->enumFqcn,
+                get_debug_type($data)
+            ));
+        }
+
+        return (string) $data->value;
     }
 
+    /** @throws ConverterException */
     public function toPgStandardFormat(mixed $data, string $type, Session $session): ?string
     {
         return $this->toPg($data, $type, $session);

--- a/sources/lib/Converter/PgFloat.php
+++ b/sources/lib/Converter/PgFloat.php
@@ -22,6 +22,8 @@ use PommProject\Foundation\Session\Session;
  */
 class PgFloat implements ConverterInterface
 {
+    use UnwrapsEnum;
+
     /** @see ConverterInterface */
     public function fromPg(?string $data, string $type, Session $session): ?float
     {
@@ -43,7 +45,7 @@ class PgFloat implements ConverterInterface
      */
     public function toPg(mixed $data, string $type, Session $session): string
     {
-        $data = $this->normalizeEnum($data, $type);
+        $data = $this->unwrapEnum($data, $type);
 
         return $data !== null ? sprintf("%s '%s'", $type, $data) : sprintf("NULL::%s", $type);
     }
@@ -54,26 +56,13 @@ class PgFloat implements ConverterInterface
      */
     public function toPgStandardFormat(mixed $data, string $type, Session $session): ?string
     {
-        $data = $this->normalizeEnum($data, $type);
+        $data = $this->unwrapEnum($data, $type);
 
         return $data !== null ? sprintf('%s', $data) : null;
     }
 
-    /** @throws ConverterException */
-    private function normalizeEnum(mixed $data, string $type): mixed
+    protected function acceptsEnum(\UnitEnum $enum): bool
     {
-        if ($data instanceof \UnitEnum) {
-            if (!$data instanceof \BackedEnum || !is_int($data->value)) {
-                throw new ConverterException(sprintf(
-                    "Enum '%s' cannot be converted to float type '%s' (requires an int-backed enum).",
-                    $data::class,
-                    $type
-                ));
-            }
-
-            return $data->value;
-        }
-
-        return $data;
+        return $enum instanceof \BackedEnum && is_numeric($enum->value);
     }
 }

--- a/sources/lib/Converter/PgFloat.php
+++ b/sources/lib/Converter/PgFloat.php
@@ -9,6 +9,7 @@
  */
 namespace PommProject\Foundation\Converter;
 
+use PommProject\Foundation\Exception\ConverterException;
 use PommProject\Foundation\Session\Session;
 
 /**
@@ -36,15 +37,43 @@ class PgFloat implements ConverterInterface
         return (float) $data;
     }
 
-    /** @see ConverterInterface */
+    /**
+     * @throws ConverterException
+     * @see ConverterInterface
+     */
     public function toPg(mixed $data, string $type, Session $session): string
     {
+        $data = $this->normalizeEnum($data, $type);
+
         return $data !== null ? sprintf("%s '%s'", $type, $data) : sprintf("NULL::%s", $type);
     }
 
-    /** @see ConverterInterface */
+    /**
+     * @throws ConverterException
+     * @see ConverterInterface
+     */
     public function toPgStandardFormat(mixed $data, string $type, Session $session): ?string
     {
+        $data = $this->normalizeEnum($data, $type);
+
         return $data !== null ? sprintf('%s', $data) : null;
+    }
+
+    /** @throws ConverterException */
+    private function normalizeEnum(mixed $data, string $type): mixed
+    {
+        if ($data instanceof \UnitEnum) {
+            if (!$data instanceof \BackedEnum || !is_int($data->value)) {
+                throw new ConverterException(sprintf(
+                    "Enum '%s' cannot be converted to float type '%s' (requires an int-backed enum).",
+                    $data::class,
+                    $type
+                ));
+            }
+
+            return $data->value;
+        }
+
+        return $data;
     }
 }

--- a/sources/lib/Converter/PgInteger.php
+++ b/sources/lib/Converter/PgInteger.php
@@ -9,6 +9,7 @@
  */
 namespace PommProject\Foundation\Converter;
 
+use PommProject\Foundation\Exception\ConverterException;
 use PommProject\Foundation\Session\Session;
 
 /**
@@ -36,15 +37,43 @@ class PgInteger implements ConverterInterface
         return (int) $data;
     }
 
-    /** @see ConverterInterface */
+    /**
+     * @throws ConverterException
+     * @see ConverterInterface
+     */
     public function toPg(mixed $data, string $type, Session $session): string
     {
+        $data = $this->normalizeEnum($data, $type);
+
         return $data !== null ? sprintf("%s '%u'", $type, $data) : sprintf("NULL::%s", $type);
     }
 
-    /** @see ConverterInterface */
+    /**
+     * @throws ConverterException
+     * @see ConverterInterface
+     */
     public function toPgStandardFormat(mixed $data, string $type, Session $session): ?string
     {
+        $data = $this->normalizeEnum($data, $type);
+
         return $data !== null ? sprintf('%u', $data) : null;
+    }
+
+    /** @throws ConverterException */
+    private function normalizeEnum(mixed $data, string $type): mixed
+    {
+        if ($data instanceof \UnitEnum) {
+            if (!$data instanceof \BackedEnum || !is_int($data->value)) {
+                throw new ConverterException(sprintf(
+                    "Enum '%s' cannot be converted to integer type '%s' (requires an int-backed enum).",
+                    $data::class,
+                    $type
+                ));
+            }
+
+            return $data->value;
+        }
+
+        return $data;
     }
 }

--- a/sources/lib/Converter/PgInteger.php
+++ b/sources/lib/Converter/PgInteger.php
@@ -22,6 +22,8 @@ use PommProject\Foundation\Session\Session;
  */
 class PgInteger implements ConverterInterface
 {
+    use UnwrapsEnum;
+
     /** @see ConverterInterface */
     public function fromPg(?string $data, string $type, Session $session): ?int
     {
@@ -43,9 +45,9 @@ class PgInteger implements ConverterInterface
      */
     public function toPg(mixed $data, string $type, Session $session): string
     {
-        $data = $this->normalizeEnum($data, $type);
+        $data = $this->unwrapEnum($data, $type);
 
-        return $data !== null ? sprintf("%s '%u'", $type, $data) : sprintf("NULL::%s", $type);
+        return $data !== null ? sprintf("%s '%d'", $type, $data) : sprintf("NULL::%s", $type);
     }
 
     /**
@@ -54,26 +56,13 @@ class PgInteger implements ConverterInterface
      */
     public function toPgStandardFormat(mixed $data, string $type, Session $session): ?string
     {
-        $data = $this->normalizeEnum($data, $type);
+        $data = $this->unwrapEnum($data, $type);
 
-        return $data !== null ? sprintf('%u', $data) : null;
+        return $data !== null ? sprintf('%d', $data) : null;
     }
 
-    /** @throws ConverterException */
-    private function normalizeEnum(mixed $data, string $type): mixed
+    protected function acceptsEnum(\UnitEnum $enum): bool
     {
-        if ($data instanceof \UnitEnum) {
-            if (!$data instanceof \BackedEnum || !is_int($data->value)) {
-                throw new ConverterException(sprintf(
-                    "Enum '%s' cannot be converted to integer type '%s' (requires an int-backed enum).",
-                    $data::class,
-                    $type
-                ));
-            }
-
-            return $data->value;
-        }
-
-        return $data;
+        return $enum instanceof \BackedEnum && is_int($enum->value);
     }
 }

--- a/sources/lib/Converter/PgString.php
+++ b/sources/lib/Converter/PgString.php
@@ -24,13 +24,15 @@ use PommProject\Foundation\Session\Session;
  */
 class PgString implements ConverterInterface
 {
+    use UnwrapsEnum;
+
     /**
      * @throws ConnectionException|ConverterException|FoundationException
      * @see ConverterInterface
      */
     public function toPg(mixed $data, string $type, Session $session): string
     {
-        $data = $this->normalizeEnum($data, $type);
+        $data = $this->unwrapEnum($data, $type);
 
         return $data !== null
             ? sprintf("%s %s",  $type, $session->getConnection()->escapeLiteral($data))
@@ -43,34 +45,17 @@ class PgString implements ConverterInterface
      */
     public function toPgStandardFormat(mixed $data, string $type, Session $session): ?string
     {
-        return $this->normalizeEnum($data, $type);
-    }
-
-    /** @throws ConverterException */
-    private function normalizeEnum(mixed $data, string $type): ?string
-    {
-        if ($data instanceof \BackedEnum) {
-            if (!is_string($data->value)) {
-                throw new ConverterException(sprintf(
-                    "BackedEnum '%s' is int-backed and cannot be converted to string type '%s'.",
-                    $data::class,
-                    $type
-                ));
-            }
-
-            return $data->value;
-        }
-
-        if ($data instanceof \UnitEnum) {
-            return $data->name;
-        }
-
-        return $data;
+        return $this->unwrapEnum($data, $type);
     }
 
     /** @see ConverterInterface */
     public function fromPg(?string $data, string $type, Session $session): ?string
     {
         return $data;
+    }
+
+    protected function acceptsEnum(\UnitEnum $enum): bool
+    {
+        return !$enum instanceof \BackedEnum || is_string($enum->value);
     }
 }

--- a/sources/lib/Converter/PgString.php
+++ b/sources/lib/Converter/PgString.php
@@ -10,6 +10,7 @@
 namespace PommProject\Foundation\Converter;
 
 use PommProject\Foundation\Exception\ConnectionException;
+use PommProject\Foundation\Exception\ConverterException;
 use PommProject\Foundation\Exception\FoundationException;
 use PommProject\Foundation\Session\Session;
 
@@ -24,19 +25,46 @@ use PommProject\Foundation\Session\Session;
 class PgString implements ConverterInterface
 {
     /**
-     * @throws ConnectionException|FoundationException
+     * @throws ConnectionException|ConverterException|FoundationException
      * @see ConverterInterface
      */
     public function toPg(mixed $data, string $type, Session $session): string
     {
+        $data = $this->normalizeEnum($data, $type);
+
         return $data !== null
             ? sprintf("%s %s",  $type, $session->getConnection()->escapeLiteral($data))
             : sprintf("NULL::%s", $type);
     }
 
-    /** @see ConverterInterface */
+    /**
+     * @throws ConverterException
+     * @see ConverterInterface
+     */
     public function toPgStandardFormat(mixed $data, string $type, Session $session): ?string
     {
+        return $this->normalizeEnum($data, $type);
+    }
+
+    /** @throws ConverterException */
+    private function normalizeEnum(mixed $data, string $type): ?string
+    {
+        if ($data instanceof \BackedEnum) {
+            if (!is_string($data->value)) {
+                throw new ConverterException(sprintf(
+                    "BackedEnum '%s' is int-backed and cannot be converted to string type '%s'.",
+                    $data::class,
+                    $type
+                ));
+            }
+
+            return $data->value;
+        }
+
+        if ($data instanceof \UnitEnum) {
+            return $data->name;
+        }
+
         return $data;
     }
 

--- a/sources/lib/Converter/UnwrapsEnum.php
+++ b/sources/lib/Converter/UnwrapsEnum.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PommProject\Foundation\Converter;
+
+use PommProject\Foundation\Exception\ConverterException;
+
+/**
+ * Shared entry point to unwrap PHP enums into scalar values usable by the
+ * primitive Pg* converters. Each consumer only declares which enums it
+ * {@see acceptsEnum() accepts}; the trait handles value extraction and
+ * rejection.
+ */
+trait UnwrapsEnum
+{
+    /** @throws ConverterException */
+    private function unwrapEnum(mixed $data, string $type): mixed
+    {
+        return $data instanceof \UnitEnum
+            ? $this->convertEnumValue($data, $type)
+            : $data;
+    }
+
+    /** @throws ConverterException */
+    protected function convertEnumValue(\UnitEnum $enum, string $type): string|int
+    {
+        if (!$this->acceptsEnum($enum)) {
+            throw new ConverterException(sprintf(
+                "Enum '%s' is not compatible with Pg type '%s'.",
+                $enum::class,
+                $type
+            ));
+        }
+
+        return $enum instanceof \BackedEnum ? $enum->value : $enum->name;
+    }
+
+    /** Whether this converter accepts the given enum instance. */
+    abstract protected function acceptsEnum(\UnitEnum $enum): bool;
+}

--- a/sources/tests/Unit/Converter/PgFloat.php
+++ b/sources/tests/Unit/Converter/PgFloat.php
@@ -12,7 +12,7 @@ namespace PommProject\Foundation\Test\Unit\Converter;
 use PommProject\Foundation\Exception\FoundationException;
 use PommProject\Foundation\Test\Unit\Enum\BackedEnum;
 use PommProject\Foundation\Test\Unit\Enum\IntBackedEnum;
-use PommProject\Foundation\Test\Unit\Enum\PureEnum;
+use PommProject\Foundation\Test\Unit\Enum\UnitEnum;
 
 class PgFloat extends BaseConverter
 {
@@ -51,10 +51,10 @@ class PgFloat extends BaseConverter
                 "Enum '%s' is not compatible with Pg type 'float8'.",
                 BackedEnum::class
             ))
-            ->exception(fn() => $this->newTestedInstance()->toPg(PureEnum::Active, 'float8', $session))
+            ->exception(fn() => $this->newTestedInstance()->toPg(UnitEnum::Active, 'float8', $session))
             ->hasMessage(sprintf(
                 "Enum '%s' is not compatible with Pg type 'float8'.",
-                PureEnum::class
+                UnitEnum::class
             ));
     }
 
@@ -77,10 +77,10 @@ class PgFloat extends BaseConverter
                 "Enum '%s' is not compatible with Pg type 'float8'.",
                 BackedEnum::class
             ))
-            ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(PureEnum::Active, 'float8', $session))
+            ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(UnitEnum::Active, 'float8', $session))
             ->hasMessage(sprintf(
                 "Enum '%s' is not compatible with Pg type 'float8'.",
-                PureEnum::class
+                UnitEnum::class
             ));
     }
 }

--- a/sources/tests/Unit/Converter/PgFloat.php
+++ b/sources/tests/Unit/Converter/PgFloat.php
@@ -10,6 +10,9 @@
 namespace PommProject\Foundation\Test\Unit\Converter;
 
 use PommProject\Foundation\Exception\FoundationException;
+use PommProject\Foundation\Test\Unit\Enum\BackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\IntBackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\PureEnum;
 
 class PgFloat extends BaseConverter
 {
@@ -38,7 +41,19 @@ class PgFloat extends BaseConverter
             ->string($this->newTestedInstance()->toPg(null, 'float8', $session))
             ->isEqualTo("NULL::float8")
             ->string($this->newTestedInstance()->toPg(0, 'float8', $session))
-            ->isEqualTo("float8 '0'");
+            ->isEqualTo("float8 '0'")
+            ->string($this->newTestedInstance()->toPg(IntBackedEnum::TWO, 'float8', $session))
+            ->isEqualTo("float8 '2'")
+            ->exception(fn() => $this->newTestedInstance()->toPg(BackedEnum::A, 'float8', $session))
+            ->hasMessage(sprintf(
+                "Enum '%s' cannot be converted to float type 'float8' (requires an int-backed enum).",
+                BackedEnum::class
+            ))
+            ->exception(fn() => $this->newTestedInstance()->toPg(PureEnum::Active, 'float8', $session))
+            ->hasMessage(sprintf(
+                "Enum '%s' cannot be converted to float type 'float8' (requires an int-backed enum).",
+                PureEnum::class
+            ));
     }
 
     /** @throws FoundationException */
@@ -50,6 +65,18 @@ class PgFloat extends BaseConverter
             ->string($this->newTestedInstance()->toPgStandardFormat(1.6180339887499, 'float8', $session))
             ->isEqualTo("1.6180339887499")
             ->variable($this->newTestedInstance()->toPgStandardFormat(null, 'float8', $session))
-            ->isNull();
+            ->isNull()
+            ->string($this->newTestedInstance()->toPgStandardFormat(IntBackedEnum::TWO, 'float8', $session))
+            ->isEqualTo('2')
+            ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(BackedEnum::A, 'float8', $session))
+            ->hasMessage(sprintf(
+                "Enum '%s' cannot be converted to float type 'float8' (requires an int-backed enum).",
+                BackedEnum::class
+            ))
+            ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(PureEnum::Active, 'float8', $session))
+            ->hasMessage(sprintf(
+                "Enum '%s' cannot be converted to float type 'float8' (requires an int-backed enum).",
+                PureEnum::class
+            ));
     }
 }

--- a/sources/tests/Unit/Converter/PgFloat.php
+++ b/sources/tests/Unit/Converter/PgFloat.php
@@ -44,14 +44,16 @@ class PgFloat extends BaseConverter
             ->isEqualTo("float8 '0'")
             ->string($this->newTestedInstance()->toPg(IntBackedEnum::TWO, 'float8', $session))
             ->isEqualTo("float8 '2'")
+            ->string($this->newTestedInstance()->toPg(BackedEnum::NUMERIC, 'float8', $session))
+            ->isEqualTo("float8 '42.5'")
             ->exception(fn() => $this->newTestedInstance()->toPg(BackedEnum::A, 'float8', $session))
             ->hasMessage(sprintf(
-                "Enum '%s' cannot be converted to float type 'float8' (requires an int-backed enum).",
+                "Enum '%s' is not compatible with Pg type 'float8'.",
                 BackedEnum::class
             ))
             ->exception(fn() => $this->newTestedInstance()->toPg(PureEnum::Active, 'float8', $session))
             ->hasMessage(sprintf(
-                "Enum '%s' cannot be converted to float type 'float8' (requires an int-backed enum).",
+                "Enum '%s' is not compatible with Pg type 'float8'.",
                 PureEnum::class
             ));
     }
@@ -68,14 +70,16 @@ class PgFloat extends BaseConverter
             ->isNull()
             ->string($this->newTestedInstance()->toPgStandardFormat(IntBackedEnum::TWO, 'float8', $session))
             ->isEqualTo('2')
+            ->string($this->newTestedInstance()->toPgStandardFormat(BackedEnum::NUMERIC, 'float8', $session))
+            ->isEqualTo('42.5')
             ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(BackedEnum::A, 'float8', $session))
             ->hasMessage(sprintf(
-                "Enum '%s' cannot be converted to float type 'float8' (requires an int-backed enum).",
+                "Enum '%s' is not compatible with Pg type 'float8'.",
                 BackedEnum::class
             ))
             ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(PureEnum::Active, 'float8', $session))
             ->hasMessage(sprintf(
-                "Enum '%s' cannot be converted to float type 'float8' (requires an int-backed enum).",
+                "Enum '%s' is not compatible with Pg type 'float8'.",
                 PureEnum::class
             ));
     }

--- a/sources/tests/Unit/Converter/PgInteger.php
+++ b/sources/tests/Unit/Converter/PgInteger.php
@@ -42,16 +42,18 @@ class PgInteger extends BaseConverter
             ->isEqualTo("NULL::int4")
             ->string($this->newTestedInstance()->toPg(0, 'int4', $session))
             ->isEqualTo("int4 '0'")
+            ->string($this->newTestedInstance()->toPg(-42, 'int4', $session))
+            ->isEqualTo("int4 '-42'")
             ->string($this->newTestedInstance()->toPg(IntBackedEnum::TWO, 'int4', $session))
             ->isEqualTo("int4 '2'")
             ->exception(fn() => $this->newTestedInstance()->toPg(BackedEnum::A, 'int4', $session))
             ->hasMessage(sprintf(
-                "Enum '%s' cannot be converted to integer type 'int4' (requires an int-backed enum).",
+                "Enum '%s' is not compatible with Pg type 'int4'.",
                 BackedEnum::class
             ))
             ->exception(fn() => $this->newTestedInstance()->toPg(PureEnum::Active, 'int4', $session))
             ->hasMessage(sprintf(
-                "Enum '%s' cannot be converted to integer type 'int4' (requires an int-backed enum).",
+                "Enum '%s' is not compatible with Pg type 'int4'.",
                 PureEnum::class
             ));
     }
@@ -66,16 +68,18 @@ class PgInteger extends BaseConverter
             ->isEqualTo("1")
             ->variable($this->newTestedInstance()->toPgStandardFormat(null, 'int4', $session))
             ->isNull()
+            ->string($this->newTestedInstance()->toPgStandardFormat(-42, 'int4', $session))
+            ->isEqualTo('-42')
             ->string($this->newTestedInstance()->toPgStandardFormat(IntBackedEnum::TWO, 'int4', $session))
             ->isEqualTo('2')
             ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(BackedEnum::A, 'int4', $session))
             ->hasMessage(sprintf(
-                "Enum '%s' cannot be converted to integer type 'int4' (requires an int-backed enum).",
+                "Enum '%s' is not compatible with Pg type 'int4'.",
                 BackedEnum::class
             ))
             ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(PureEnum::Active, 'int4', $session))
             ->hasMessage(sprintf(
-                "Enum '%s' cannot be converted to integer type 'int4' (requires an int-backed enum).",
+                "Enum '%s' is not compatible with Pg type 'int4'.",
                 PureEnum::class
             ));
     }

--- a/sources/tests/Unit/Converter/PgInteger.php
+++ b/sources/tests/Unit/Converter/PgInteger.php
@@ -12,7 +12,7 @@ namespace PommProject\Foundation\Test\Unit\Converter;
 use PommProject\Foundation\Exception\FoundationException;
 use PommProject\Foundation\Test\Unit\Enum\BackedEnum;
 use PommProject\Foundation\Test\Unit\Enum\IntBackedEnum;
-use PommProject\Foundation\Test\Unit\Enum\PureEnum;
+use PommProject\Foundation\Test\Unit\Enum\UnitEnum;
 
 class PgInteger extends BaseConverter
 {
@@ -51,10 +51,10 @@ class PgInteger extends BaseConverter
                 "Enum '%s' is not compatible with Pg type 'int4'.",
                 BackedEnum::class
             ))
-            ->exception(fn() => $this->newTestedInstance()->toPg(PureEnum::Active, 'int4', $session))
+            ->exception(fn() => $this->newTestedInstance()->toPg(UnitEnum::Active, 'int4', $session))
             ->hasMessage(sprintf(
                 "Enum '%s' is not compatible with Pg type 'int4'.",
-                PureEnum::class
+                UnitEnum::class
             ));
     }
 
@@ -77,10 +77,10 @@ class PgInteger extends BaseConverter
                 "Enum '%s' is not compatible with Pg type 'int4'.",
                 BackedEnum::class
             ))
-            ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(PureEnum::Active, 'int4', $session))
+            ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(UnitEnum::Active, 'int4', $session))
             ->hasMessage(sprintf(
                 "Enum '%s' is not compatible with Pg type 'int4'.",
-                PureEnum::class
+                UnitEnum::class
             ));
     }
 }

--- a/sources/tests/Unit/Converter/PgInteger.php
+++ b/sources/tests/Unit/Converter/PgInteger.php
@@ -10,6 +10,9 @@
 namespace PommProject\Foundation\Test\Unit\Converter;
 
 use PommProject\Foundation\Exception\FoundationException;
+use PommProject\Foundation\Test\Unit\Enum\BackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\IntBackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\PureEnum;
 
 class PgInteger extends BaseConverter
 {
@@ -38,7 +41,19 @@ class PgInteger extends BaseConverter
             ->string($this->newTestedInstance()->toPg(null, 'int4', $session))
             ->isEqualTo("NULL::int4")
             ->string($this->newTestedInstance()->toPg(0, 'int4', $session))
-            ->isEqualTo("int4 '0'");
+            ->isEqualTo("int4 '0'")
+            ->string($this->newTestedInstance()->toPg(IntBackedEnum::TWO, 'int4', $session))
+            ->isEqualTo("int4 '2'")
+            ->exception(fn() => $this->newTestedInstance()->toPg(BackedEnum::A, 'int4', $session))
+            ->hasMessage(sprintf(
+                "Enum '%s' cannot be converted to integer type 'int4' (requires an int-backed enum).",
+                BackedEnum::class
+            ))
+            ->exception(fn() => $this->newTestedInstance()->toPg(PureEnum::Active, 'int4', $session))
+            ->hasMessage(sprintf(
+                "Enum '%s' cannot be converted to integer type 'int4' (requires an int-backed enum).",
+                PureEnum::class
+            ));
     }
 
     /** @throws FoundationException */
@@ -50,6 +65,18 @@ class PgInteger extends BaseConverter
             ->string($this->newTestedInstance()->toPgStandardFormat(1.6180339887499, 'int4', $session))
             ->isEqualTo("1")
             ->variable($this->newTestedInstance()->toPgStandardFormat(null, 'int4', $session))
-            ->isNull();
+            ->isNull()
+            ->string($this->newTestedInstance()->toPgStandardFormat(IntBackedEnum::TWO, 'int4', $session))
+            ->isEqualTo('2')
+            ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(BackedEnum::A, 'int4', $session))
+            ->hasMessage(sprintf(
+                "Enum '%s' cannot be converted to integer type 'int4' (requires an int-backed enum).",
+                BackedEnum::class
+            ))
+            ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(PureEnum::Active, 'int4', $session))
+            ->hasMessage(sprintf(
+                "Enum '%s' cannot be converted to integer type 'int4' (requires an int-backed enum).",
+                PureEnum::class
+            ));
     }
 }

--- a/sources/tests/Unit/Converter/PgString.php
+++ b/sources/tests/Unit/Converter/PgString.php
@@ -54,7 +54,7 @@ class PgString extends BaseConverter
             ->isEqualTo("varchar 'Active'")
             ->exception(fn() => $this->newTestedInstance()->toPg(IntBackedEnum::TWO, 'varchar', $session))
             ->hasMessage(sprintf(
-                "BackedEnum '%s' is int-backed and cannot be converted to string type 'varchar'.",
+                "Enum '%s' is not compatible with Pg type 'varchar'.",
                 IntBackedEnum::class
             ));
     }
@@ -80,7 +80,7 @@ class PgString extends BaseConverter
             ->isEqualTo('Active')
             ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(IntBackedEnum::TWO, 'varchar', $session))
             ->hasMessage(sprintf(
-                "BackedEnum '%s' is int-backed and cannot be converted to string type 'varchar'.",
+                "Enum '%s' is not compatible with Pg type 'varchar'.",
                 IntBackedEnum::class
             ));
     }

--- a/sources/tests/Unit/Converter/PgString.php
+++ b/sources/tests/Unit/Converter/PgString.php
@@ -10,6 +10,9 @@
 namespace PommProject\Foundation\Test\Unit\Converter;
 
 use PommProject\Foundation\Exception\FoundationException;
+use PommProject\Foundation\Test\Unit\Enum\BackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\IntBackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\PureEnum;
 
 class PgString extends BaseConverter
 {
@@ -44,7 +47,16 @@ class PgString extends BaseConverter
             ->string($this->newTestedInstance()->toPg('', 'bpchar', $session))
             ->isEqualTo("bpchar ''")
             ->string($this->newTestedInstance()->toPg('10.2.3.4', 'inet', $session))
-            ->isEqualTo("inet '10.2.3.4'");
+            ->isEqualTo("inet '10.2.3.4'")
+            ->string($this->newTestedInstance()->toPg(BackedEnum::A, 'varchar', $session))
+            ->isEqualTo("varchar 'a'")
+            ->string($this->newTestedInstance()->toPg(PureEnum::Active, 'varchar', $session))
+            ->isEqualTo("varchar 'Active'")
+            ->exception(fn() => $this->newTestedInstance()->toPg(IntBackedEnum::TWO, 'varchar', $session))
+            ->hasMessage(sprintf(
+                "BackedEnum '%s' is int-backed and cannot be converted to string type 'varchar'.",
+                IntBackedEnum::class
+            ));
     }
 
     /** @throws FoundationException */
@@ -61,6 +73,15 @@ class PgString extends BaseConverter
             ->string($this->newTestedInstance()->toPgStandardFormat('', 'bpchar', $session))
             ->isEqualTo('')
             ->string($this->newTestedInstance()->toPgStandardFormat('10.2.3.4', 'inet', $session))
-            ->isEqualTo('10.2.3.4');
+            ->isEqualTo('10.2.3.4')
+            ->string($this->newTestedInstance()->toPgStandardFormat(BackedEnum::A, 'varchar', $session))
+            ->isEqualTo('a')
+            ->string($this->newTestedInstance()->toPgStandardFormat(PureEnum::Active, 'varchar', $session))
+            ->isEqualTo('Active')
+            ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(IntBackedEnum::TWO, 'varchar', $session))
+            ->hasMessage(sprintf(
+                "BackedEnum '%s' is int-backed and cannot be converted to string type 'varchar'.",
+                IntBackedEnum::class
+            ));
     }
 }

--- a/sources/tests/Unit/Converter/PgString.php
+++ b/sources/tests/Unit/Converter/PgString.php
@@ -12,7 +12,7 @@ namespace PommProject\Foundation\Test\Unit\Converter;
 use PommProject\Foundation\Exception\FoundationException;
 use PommProject\Foundation\Test\Unit\Enum\BackedEnum;
 use PommProject\Foundation\Test\Unit\Enum\IntBackedEnum;
-use PommProject\Foundation\Test\Unit\Enum\PureEnum;
+use PommProject\Foundation\Test\Unit\Enum\UnitEnum;
 
 class PgString extends BaseConverter
 {
@@ -50,7 +50,7 @@ class PgString extends BaseConverter
             ->isEqualTo("inet '10.2.3.4'")
             ->string($this->newTestedInstance()->toPg(BackedEnum::A, 'varchar', $session))
             ->isEqualTo("varchar 'a'")
-            ->string($this->newTestedInstance()->toPg(PureEnum::Active, 'varchar', $session))
+            ->string($this->newTestedInstance()->toPg(UnitEnum::Active, 'varchar', $session))
             ->isEqualTo("varchar 'Active'")
             ->exception(fn() => $this->newTestedInstance()->toPg(IntBackedEnum::TWO, 'varchar', $session))
             ->hasMessage(sprintf(
@@ -76,7 +76,7 @@ class PgString extends BaseConverter
             ->isEqualTo('10.2.3.4')
             ->string($this->newTestedInstance()->toPgStandardFormat(BackedEnum::A, 'varchar', $session))
             ->isEqualTo('a')
-            ->string($this->newTestedInstance()->toPgStandardFormat(PureEnum::Active, 'varchar', $session))
+            ->string($this->newTestedInstance()->toPgStandardFormat(UnitEnum::Active, 'varchar', $session))
             ->isEqualTo('Active')
             ->exception(fn() => $this->newTestedInstance()->toPgStandardFormat(IntBackedEnum::TWO, 'varchar', $session))
             ->hasMessage(sprintf(

--- a/sources/tests/Unit/Enum/BackedEnum.php
+++ b/sources/tests/Unit/Enum/BackedEnum.php
@@ -5,4 +5,5 @@ namespace PommProject\Foundation\Test\Unit\Enum;
 enum BackedEnum: string
 {
     case A = 'a';
+    case NUMERIC = '42.5';
 }

--- a/sources/tests/Unit/Enum/IntBackedEnum.php
+++ b/sources/tests/Unit/Enum/IntBackedEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PommProject\Foundation\Test\Unit\Enum;
+
+enum IntBackedEnum: int
+{
+    case TWO = 2;
+}

--- a/sources/tests/Unit/Enum/PureEnum.php
+++ b/sources/tests/Unit/Enum/PureEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PommProject\Foundation\Test\Unit\Enum;
+
+enum PureEnum
+{
+    case Active;
+}

--- a/sources/tests/Unit/Enum/UnitEnum.php
+++ b/sources/tests/Unit/Enum/UnitEnum.php
@@ -2,7 +2,7 @@
 
 namespace PommProject\Foundation\Test\Unit\Enum;
 
-enum PureEnum
+enum UnitEnum
 {
     case Active;
 }


### PR DESCRIPTION
BackedEnum instances are now unwrapped to their backing value when the backing type matches the target PG type (string for PgString, int for PgInteger/PgFloat); mismatched backings raise a ConverterException. PgString also accepts pure UnitEnum instances and uses their name.