### PR TITLE
Support PHP enums in Where::createWhereIn and untyped $* placeholders

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+== VERSION 4.0.4
+
+ * Fix Where::createWhereIn / createWhereNotIn crashing on PHP enum values (RecursiveArrayIterator rejects enums on PHP 8.1+); flatten via array_walk_recursive instead
+ * Unwrap PHP enums to scalars on bare $* placeholders in SimpleQueryManager and PreparedQuery (BackedEnum->value, UnitEnum->name) so untyped IN clauses with enums work end-to-end
+
 == VERSION 4.0.3
 
  * Accept PHP enums in PgString, PgInteger and PgFloat converters (scalar unwrapping with per-converter compatibility check; PgString also handles pure UnitEnum via ->name)

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.3",
+    "version": "4.0.4",
     "name": "conserto/pomm-foundation",
     "type": "library",
     "description":  "Pomm connection manager for Postgresql",

--- a/sources/lib/PreparedQuery/PreparedQuery.php
+++ b/sources/lib/PreparedQuery/PreparedQuery.php
@@ -176,6 +176,8 @@ class PreparedQuery extends Client
         foreach ($values as $index => $value) {
             if (isset($this->converters[$index])) {
                 $values[$index] = call_user_func($this->converters[$index], $value);
+            } elseif ($value instanceof \UnitEnum) {
+                $values[$index] = $value instanceof \BackedEnum ? $value->value : $value->name;
             }
         }
 

--- a/sources/lib/QueryManager/SimpleQueryManager.php
+++ b/sources/lib/QueryManager/SimpleQueryManager.php
@@ -84,6 +84,8 @@ class SimpleQueryManager extends QueryManagerClient
                     ->getClientUsingPooler('converter', $types[$index]);
 
                 $parameters[$index] = $converterClient->toPgStandardFormat($value, $types[$index]);
+            } elseif ($value instanceof \UnitEnum) {
+                $parameters[$index] = $value instanceof \BackedEnum ? $value->value : $value->name;
             }
         }
 

--- a/sources/lib/Where.php
+++ b/sources/lib/Where.php
@@ -102,10 +102,9 @@ class Where implements \Stringable
     protected static function extractValues(array $values): array
     {
         $array = [];
-
-        foreach (new \RecursiveIteratorIterator(new \RecursiveArrayIterator($values)) as $value) {
+        array_walk_recursive($values, function (mixed $value) use (&$array): void {
             $array[] = $value;
-        }
+        });
 
         return $array;
     }

--- a/sources/tests/Unit/PreparedQuery/PreparedQuery.php
+++ b/sources/tests/Unit/PreparedQuery/PreparedQuery.php
@@ -13,6 +13,9 @@ use PommProject\Foundation\Converter\Type\Circle;
 use PommProject\Foundation\Exception\FoundationException;
 use PommProject\Foundation\PreparedQuery\PreparedQuery as TestedPreparedQuery;
 use PommProject\Foundation\Session\Session;
+use PommProject\Foundation\Test\Unit\Enum\BackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\IntBackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\UnitEnum as TestUnitEnum;
 use PommProject\Foundation\Tester\FoundationSessionAtoum;
 
 class PreparedQuery extends FoundationSessionAtoum
@@ -53,6 +56,28 @@ SQL;
         );
 
         $this->integer($result->countRows())->isEqualTo(2);
+    }
+
+    /**
+     * @throws FoundationException
+     *
+     * Untyped $* placeholders must accept PHP enums and forward their scalar
+     * value (or name for unit enums) to the driver, since the converter pooler
+     * is not invoked when no type hint is present.
+     */
+    public function testExecuteWithEnumOnUntypedPlaceholder(): void
+    {
+        $session = $this->buildSession();
+
+        $query = $this->newTestedInstance('select $* as v');
+        $session->registerClient($query);
+
+        $this->variable($query->execute([BackedEnum::A])->fetchRow(0)['v'])
+            ->isEqualTo(BackedEnum::A->value);
+        $this->variable($query->execute([IntBackedEnum::TWO])->fetchRow(0)['v'])
+            ->isEqualTo((string) IntBackedEnum::TWO->value);
+        $this->variable($query->execute([TestUnitEnum::Active])->fetchRow(0)['v'])
+            ->isEqualTo(TestUnitEnum::Active->name);
     }
 
     protected function initializeSession(Session $session): void

--- a/sources/tests/Unit/QueryManager/SimpleQueryManager.php
+++ b/sources/tests/Unit/QueryManager/SimpleQueryManager.php
@@ -14,7 +14,11 @@ use PommProject\Foundation\Converter\Type\Circle;
 use PommProject\Foundation\Exception\FoundationException;
 use PommProject\Foundation\Exception\SqlException;
 use PommProject\Foundation\Session\Session;
+use PommProject\Foundation\Test\Unit\Enum\BackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\IntBackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\UnitEnum as TestUnitEnum;
 use PommProject\Foundation\Tester\FoundationSessionAtoum;
+use PommProject\Foundation\Where;
 
 class SimpleQueryManager extends FoundationSessionAtoum
 {
@@ -104,6 +108,31 @@ SQL;
             ->isEqualTo('test session')
             ->integer($listener_tester->result_count)
             ->isEqualTo(1);
+    }
+
+    /**
+     * @throws FoundationException
+     *
+     * Bare $* placeholders (e.g. those built by Where::createWhereIn) carry no
+     * type cast, so the value must still reach the driver as a scalar when it's
+     * a PHP enum rather than a primitive.
+     */
+    public function testQueryWithEnumOnUntypedPlaceholder(): void
+    {
+        $session = $this->buildSession();
+
+        $where = Where::createWhereIn("'a'::text", [BackedEnum::A, BackedEnum::NUMERIC]);
+        $iterator = $this->getQueryManager($session)
+            ->query(sprintf('select %s as match', (string) $where), $where->getValues());
+        $this->boolean($iterator->current()['match'])->isTrue();
+
+        $iterator = $this->getQueryManager($session)
+            ->query('select $* as v', [IntBackedEnum::TWO]);
+        $this->variable($iterator->current()['v'])->isEqualTo(IntBackedEnum::TWO->value);
+
+        $iterator = $this->getQueryManager($session)
+            ->query('select $* as v', [TestUnitEnum::Active]);
+        $this->variable($iterator->current()['v'])->isEqualTo(TestUnitEnum::Active->name);
     }
 
     protected function initializeSession(Session $session): void

--- a/sources/tests/Unit/Where.php
+++ b/sources/tests/Unit/Where.php
@@ -10,6 +10,9 @@
 namespace PommProject\Foundation\Test\Unit;
 
 use Atoum;
+use PommProject\Foundation\Test\Unit\Enum\BackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\IntBackedEnum;
+use PommProject\Foundation\Test\Unit\Enum\UnitEnum as TestUnitEnum;
 use PommProject\Foundation\Where as PommWhere;
 
 class Where extends Atoum
@@ -32,6 +35,24 @@ class Where extends Atoum
             ->isEqualTo('b IN ($*, $*, $*, $*)')
             ->string($where2->__toString())
             ->isEqualTo('(a, b) IN (($*, $*), ($*, $*))');
+    }
+
+    /**
+     * Enum values must be carried as-is through extractValues — RecursiveArrayIterator
+     * rejects enum instances on PHP 8.1+, so the flattening step must not descend into
+     * objects.
+     */
+    public function testCreateWhereInWithEnumValues(): void
+    {
+        $where = PommWhere::createWhereIn('col', [BackedEnum::A, BackedEnum::NUMERIC]);
+        $this->string($where->__toString())
+            ->isEqualTo('col IN ($*, $*)')
+            ->array($where->getValues())
+            ->isIdenticalTo([BackedEnum::A, BackedEnum::NUMERIC]);
+
+        $where = PommWhere::createWhereIn('col', [IntBackedEnum::TWO, TestUnitEnum::Active]);
+        $this->array($where->getValues())
+            ->isIdenticalTo([IntBackedEnum::TWO, TestUnitEnum::Active]);
     }
 
     public function testCreateWhereNotIn(): void


### PR DESCRIPTION
Where::extractValues used RecursiveArrayIterator, which rejects enum instances on PHP 8.1+; flatten via array_walk_recursive instead. SimpleQueryManager and PreparedQuery now unwrap UnitEnum/BackedEnum values when the placeholder carries no type cast, so untyped IN clauses built from enums round-trip end-to-end.